### PR TITLE
Updated travis config to use latest D8 release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,8 @@ install:
 
 before_script:
   # Checkout a directory structure with all dependencies.
-  - git clone --depth 1 --branch 8.0.x http://git.drupal.org/project/drupal.git $TRAVIS_BUILD_DIR/../drupal
+  - cd $TRAVIS_BUILD_DIR/..
+  - drush --yes dl drupal-8 --drupal-project-rename=drupal
   - git clone --branch 8.x-1.x https://github.com/dickolsson/drupal-key_value.git $TRAVIS_BUILD_DIR/../drupal/modules/key_value
   - ln -s $TRAVIS_BUILD_DIR $TRAVIS_BUILD_DIR/../drupal/modules/multiversion
 


### PR DESCRIPTION
It appears as though the drush dl command with --destination option doesn't respect level up [..] so a quick solution was just to cd there first and rename the output folder name.