### PR TITLE
New revision creation fixes

### DIFF
--- a/src/Entity/Index/RevisionTreeIndex.php
+++ b/src/Entity/Index/RevisionTreeIndex.php
@@ -141,6 +141,10 @@ class RevisionTreeIndex implements RevisionTreeIndexInterface {
    */
   protected static function doBuildTree($revs, $revs_info, $parse = 0, &$tree = array(), &$open_revs = array(), &$conflicts = array()) {
     foreach ($revs as $rev => $parent_rev) {
+      if ($rev == 0) {
+        continue;
+      }
+
       if ($parent_rev == $parse) {
 
         // Avoid bad data to cause endless loops.

--- a/src/Entity/Index/RevisionTreeIndex.php
+++ b/src/Entity/Index/RevisionTreeIndex.php
@@ -206,7 +206,9 @@ class RevisionTreeIndex implements RevisionTreeIndexInterface {
       $default_branch = array();
       $rev = $default_rev;
       while ($rev != 0) {
-        $default_branch[$rev] = $revs_info[$rev]['status'];
+        if (isset($revs_info[$rev])) {
+          $default_branch[$rev] = $revs_info[$rev]['status'];
+        }
         $rev = $revs[$rev];
       }
       return array(

--- a/src/Entity/Storage/ContentEntityStorageTrait.php
+++ b/src/Entity/Storage/ContentEntityStorageTrait.php
@@ -174,14 +174,14 @@ trait ContentEntityStorageTrait {
 
     // Decide whether or not this is the default revision.
     if (!$entity->isNew()) {
-      $default_rev = \Drupal::service('entity.index.rev.tree')->getDefaultRevision($entity->uuid());
-      if ($entity->_rev->value == $default_rev) {
+//      $default_rev = \Drupal::service('entity.index.rev.tree')->getDefaultRevision($entity->uuid());
+//      if ($entity->_rev->value == $default_rev) {
         $entity->isDefaultRevision(TRUE);
-      }
-      // @todo: Needs test.
-      else {
-        $entity->isDefaultRevision(FALSE);
-      }
+//      }
+//      // @todo: Needs test.
+//      else {
+//        $entity->isDefaultRevision(FALSE);
+//      }
     }
 
     return parent::doSave($id, $entity);

--- a/src/Entity/Storage/ContentEntityStorageTrait.php
+++ b/src/Entity/Storage/ContentEntityStorageTrait.php
@@ -174,14 +174,14 @@ trait ContentEntityStorageTrait {
 
     // Decide whether or not this is the default revision.
     if (!$entity->isNew()) {
-//      $default_rev = \Drupal::service('entity.index.rev.tree')->getDefaultRevision($entity->uuid());
-//      if ($entity->_rev->value == $default_rev) {
+      $default_rev = \Drupal::service('entity.index.rev.tree')->getDefaultRevision($entity->uuid());
+      if ($entity->_rev->value == $default_rev) {
         $entity->isDefaultRevision(TRUE);
-//      }
-//      // @todo: Needs test.
-//      else {
-//        $entity->isDefaultRevision(FALSE);
-//      }
+      }
+      // @todo: Needs test.
+      else {
+        $entity->isDefaultRevision(FALSE);
+      }
     }
 
     return parent::doSave($id, $entity);

--- a/src/Workspace/SessionWorkspaceNegotiator.php
+++ b/src/Workspace/SessionWorkspaceNegotiator.php
@@ -46,9 +46,9 @@ class SessionWorkspaceNegotiator extends WorkspaceNegotiatorBase implements Work
 
     // If we have an error on the requested page, set links URL to be <front>.
     if (!empty($query['_exception_statuscode'])) {
-      if ($workspace = $query['workspace']) {
+      if (isset($query['workspace'])) {
         $query = array(
-          'workspace' => $workspace,
+          'workspace' => $query['workspace'],
         );
       }
       $url = URL::fromRoute('<front>');


### PR DESCRIPTION
@dickolsson I've commented the code in `ContentEntityStorageTrait::doSave()` because I'm not sure if we need this.  When using this I get `'Child and parent revision can not be the same value.'` error in `RevisionTreeIndex::doBuildTree()`.