### PR TITLE
Fix workspace entity links

### DIFF
--- a/src/Entity/Workspace.php
+++ b/src/Entity/Workspace.php
@@ -28,7 +28,8 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *     },
  *   },
  *   links = {
- *     "edit-form" = "/workspace/{workspace}/edit",
+ *     "canonical" = "/admin/structure/workspaces/{workspace}",
+ *     "edit-form" = "/admin/structure/workspaces/{workspace}/edit",
  *     "collection" = "/admin/structure/workspaces"
  *   },
  *   admin_permission = "administer workspaces",


### PR DESCRIPTION
The annotation for these links needs to be present for the rest module to hook into. If the canonical link is missing, the rest module causes this PHP error when POSTing a new workspace: `	Drupal\Core\Entity\Exception\UndefinedLinkTemplateException: No link template 'canonical' found for the 'workspace' entity type in Drupal\Core\Entity\Entity->toUrl() (line 219 of /path/core/lib/Drupal/Core/Entity/Entity.php).`