### PR TITLE
Constraints

### DIFF
--- a/src/Entity/Workspace.php
+++ b/src/Entity/Workspace.php
@@ -67,7 +67,8 @@ class Workspace extends ContentEntityBase implements WorkspaceInterface {
       ->setLabel(t('Workaspace ID'))
       ->setDescription(t('The workspace machine name.'))
       ->setSetting('max_length', 128)
-      ->setRequired(TRUE);
+      ->setRequired(TRUE)
+      ->addPropertyConstraints('value', ['Regex' => ['pattern' => '/^[\da-z_$()+-\/]*$/']]);
 
     $fields['revision_id'] = BaseFieldDefinition::create('integer')
       ->setLabel(t('Revision ID'))

--- a/src/Tests/WorkspaceTest.php
+++ b/src/Tests/WorkspaceTest.php
@@ -58,30 +58,28 @@ class WorkspaceTest extends MultiversionWebTestBase {
     $workspace2 = Workspace::create(['label' => 'Workspace 2', 'machine_name' => 'A!"£%^&*{}#~@?']);
     $violations2 = $workspace2->validate();
     $this->assertEqual($violations2->count(), 1, 'One violation');
-  }
 
-  public function testWorkspaceForm() {
     $this->webUser = $this->drupalCreateUser([
       'administer workspaces',
     ]);
     $this->drupalLogin($this->webUser);
     $this->drupalGet('admin/structure/workspaces/add');
-    $workspace1 = [
+    $workspace3 = [
       'label' => 'Workspace 1',
       'machine_name' => 'a0_$()+-/',
     ];
-    $this->drupalPostForm('admin/structure/workspaces/add', $workspace1, t('Save'));
+    $this->drupalPostForm('admin/structure/workspaces/add', $workspace3, t('Save'));
 
     $this->drupalGet('admin/structure/workspaces');
-    $this->assertText($workspace1['label'], 'Workspace found in list of workspaces');
+    $this->assertText($workspace3['label'], 'Workspace found in list of workspaces');
 
-    $workspace2 = [
+    $workspace4 = [
       'label' => 'Workspace 2',
       'machine_name' => 'A!"£%^&*{}#~@?',
     ];
-    $this->drupalPostForm('admin/structure/workspaces/add', $workspace2, t('Save'));
+    $this->drupalPostForm('admin/structure/workspaces/add', $workspace4, t('Save'));
 
     $this->drupalGet('admin/structure/workspaces');
-    $this->assertNoText($workspace2['label'], 'Workspace not found in list of workspaces');
+    $this->assertNoText($workspace4['label'], 'Workspace not found in list of workspaces');
   }
 }

--- a/src/Tests/WorkspaceTest.php
+++ b/src/Tests/WorkspaceTest.php
@@ -48,4 +48,16 @@ class WorkspaceTest extends MultiversionWebTestBase {
     $this->assertEqual($new_created_time, $entity->getStartTime(), "Correct value for 'created' field.");
   }
 
+  public function testSpecialCharacters() {
+    //  Note that only lowercase characters (a-z), digits (0-9),
+    // or any of the characters _, $, (, ), +, -, and / are allowed.
+    $workspace1 = Workspace::create(['label' => 'Workspace 1', 'machine_name' => 'a0_$()+-/']);
+    $violations1 = $workspace1->validate();
+    $this->assertEqual($violations1->count(), 0, 'No violations');
+
+    $workspace2 = Workspace::create(['label' => 'Workspace 2', 'machine_name' => 'A!"£%^&*{}#~@?']);
+    $violations2 = $workspace2->validate();
+    $this->assertEqual($violations2->count(), 1, 'One violation');
+  }
+
 }

--- a/src/Tests/WorkspaceTest.php
+++ b/src/Tests/WorkspaceTest.php
@@ -60,4 +60,28 @@ class WorkspaceTest extends MultiversionWebTestBase {
     $this->assertEqual($violations2->count(), 1, 'One violation');
   }
 
+  public function testWorkspaceForm() {
+    $this->webUser = $this->drupalCreateUser([
+      'administer workspaces',
+    ]);
+    $this->drupalLogin($this->webUser);
+    $this->drupalGet('admin/structure/workspaces/add');
+    $workspace1 = [
+      'label' => 'Workspace 1',
+      'machine_name' => 'a0_$()+-/',
+    ];
+    $this->drupalPostForm('admin/structure/workspaces/add', $workspace1, t('Save'));
+
+    $this->drupalGet('admin/structure/workspaces');
+    $this->assertText($workspace1['label'], 'Workspace found in list of workspaces');
+
+    $workspace2 = [
+      'label' => 'Workspace 2',
+      'machine_name' => 'A!"£%^&*{}#~@?',
+    ];
+    $this->drupalPostForm('admin/structure/workspaces/add', $workspace2, t('Save'));
+
+    $this->drupalGet('admin/structure/workspaces');
+    $this->assertNoText($workspace2['label'], 'Workspace not found in list of workspaces');
+  }
 }


### PR DESCRIPTION
Added a constraint using the regex `/^[\da-z_$()+-\/]*$/` to align with the CouchDB database naming:

>
Please enter the name of the database. Note that only lowercase characters (a-z), digits (0-9), or any of the characters _, $, (, ), +, -, and / are allowed.

On the Drupal form the "machine name" is still auto generated from the label according to Drupal's machine name conventions, but the the field can be manually edited to add extra characters that CouchDB supports.

@dickolsson: Do we want to override the ajax callback that generates the machine name from the label?

Also an interesting note `$entity = Workspace::create();` doesn't do any validation, you need to manually run `$entity->validate()` to check against the field constraints. In `\Drupal\relaxed\Plugin\rest\resource\DbResource::put` and `\Drupal\relaxed\ParamConverter\DbConverter::convert` we don't do any validation when creating workspaces.