### PR TITLE
Fix migration bugs

### DIFF
--- a/multiversion.install
+++ b/multiversion.install
@@ -27,3 +27,12 @@ function multiversion_modules_installed($modules) {
 function multiversion_uninstall() {
   \Drupal::state()->delete('multiversion_enabled');
 }
+
+/**
+ * Implements hook_modules_uninstalled().
+ */
+function multiversion_modules_uninstalled($modules) {
+  if (in_array('multiversion', $modules)) {
+    \Drupal::state()->delete('multiversion.migration_done');
+  }
+}

--- a/multiversion.install
+++ b/multiversion.install
@@ -27,12 +27,3 @@ function multiversion_modules_installed($modules) {
 function multiversion_uninstall() {
   \Drupal::state()->delete('multiversion_enabled');
 }
-
-/**
- * Implements hook_modules_uninstalled().
- */
-function multiversion_modules_uninstalled($modules) {
-  if (in_array('multiversion', $modules)) {
-    \Drupal::state()->delete('multiversion.migration_done');
-  }
-}

--- a/multiversion.links.menu.yml
+++ b/multiversion.links.menu.yml
@@ -1,0 +1,5 @@
+multiversion.uninstall:
+  title: Multiversion Uninstall
+  route_name: multiversion.uninstall
+  description: 'Uninstall the Multiversion Module.'
+  parent: system.admin_config

--- a/multiversion.links.menu.yml
+++ b/multiversion.links.menu.yml
@@ -2,4 +2,4 @@ multiversion.uninstall:
   title: Multiversion Uninstall
   route_name: multiversion.uninstall
   description: 'Uninstall the Multiversion Module.'
-  parent: system.admin_config
+  parent: system.admin_config_system

--- a/multiversion.links.task.yml
+++ b/multiversion.links.task.yml
@@ -1,0 +1,5 @@
+multiversion.uninstall:
+  title: Multiversion Uninstall
+  route_name: multiversion.uninstall
+  description: 'Uninstall the Multiversion Module.'
+  base_route: multiversion.uninstall

--- a/multiversion.routing.yml
+++ b/multiversion.routing.yml
@@ -1,0 +1,9 @@
+multiversion.uninstall:
+  path: '/admin/config/multiversion-uninstall'
+  defaults:
+    _title: 'Uninstall Multiversion'
+    _form: '\Drupal\multiversion\Form\MultiversionUninstallForm'
+  requirements:
+    _permission: 'administer modules'
+  options:
+    _admin_route: TRUE

--- a/src/CommentStatistics.php
+++ b/src/CommentStatistics.php
@@ -24,87 +24,97 @@ class CommentStatistics extends CoreCommentStatistics {
    * {@inheritdoc}
    */
   public function update(CommentInterface $comment) {
-    // Allow bulk updates and inserts to temporarily disable the maintenance of
-    // the {comment_entity_statistics} table.
-    if (!$this->state->get('comment.maintain_entity_statistics')) {
-      return;
-    }
+    $storage_class = $comment->getEntityType()->getStorageClass();
+    // Do changes only if the storage class for comment entity type is provided
+    // by Multiversion. This check is needed because the 'comment.statistics'
+    // is modified before the comment entity type will be fully migrated to the
+    // new storage.
+    if (strpos($storage_class, 'Drupal\multiversion\Entity\Storage') !== FALSE) {
+      // Allow bulk updates and inserts to temporarily disable the maintenance of
+      // the {comment_entity_statistics} table.
+      if (!$this->state->get('comment.maintain_entity_statistics')) {
+        return;
+      }
 
-    $query = $this->database->select('comment_field_data', 'c');
-    $query->addExpression('COUNT(cid)');
-    $count = $query->condition('c.entity_id', $comment->getCommentedEntityId())
-      ->condition('c.entity_type', $comment->getCommentedEntityTypeId())
-      ->condition('c.field_name', $comment->getFieldName())
-      ->condition('c.status', CommentInterface::PUBLISHED)
-      ->condition('c._deleted', FALSE)
-      ->condition('default_langcode', 1)
-      ->execute()
-      ->fetchField();
-
-    if ($count > 0) {
-      // Comments exist.
-      $last_reply = $this->database->select('comment_field_data', 'c')
-        ->fields('c', array('cid', 'name', 'changed', 'uid'))
-        ->condition('c.entity_id', $comment->getCommentedEntityId())
+      $query = $this->database->select('comment_field_data', 'c');
+      $query->addExpression('COUNT(cid)');
+      $count = $query->condition('c.entity_id', $comment->getCommentedEntityId())
         ->condition('c.entity_type', $comment->getCommentedEntityTypeId())
         ->condition('c.field_name', $comment->getFieldName())
         ->condition('c.status', CommentInterface::PUBLISHED)
         ->condition('c._deleted', FALSE)
         ->condition('default_langcode', 1)
-        ->orderBy('c.created', 'DESC')
-        ->range(0, 1)
         ->execute()
-        ->fetchObject();
-      // Use merge here because entity could be created before comment field.
-      $this->database->merge('comment_entity_statistics')
-        ->fields(array(
-          'cid' => $last_reply->cid,
-          'comment_count' => $count,
-          'last_comment_timestamp' => $last_reply->changed,
-          'last_comment_name' => $last_reply->uid ? '' : $last_reply->name,
-          'last_comment_uid' => $last_reply->uid,
-        ))
-        ->keys(array(
-          'entity_id' => $comment->getCommentedEntityId(),
-          'entity_type' => $comment->getCommentedEntityTypeId(),
-          'field_name' => $comment->getFieldName(),
-        ))
-        ->execute();
+        ->fetchField();
+
+      if ($count > 0) {
+        // Comments exist.
+        $last_reply = $this->database->select('comment_field_data', 'c')
+          ->fields('c', array('cid', 'name', 'changed', 'uid'))
+          ->condition('c.entity_id', $comment->getCommentedEntityId())
+          ->condition('c.entity_type', $comment->getCommentedEntityTypeId())
+          ->condition('c.field_name', $comment->getFieldName())
+          ->condition('c.status', CommentInterface::PUBLISHED)
+          ->condition('c._deleted', FALSE)
+          ->condition('default_langcode', 1)
+          ->orderBy('c.created', 'DESC')
+          ->range(0, 1)
+          ->execute()
+          ->fetchObject();
+        // Use merge here because entity could be created before comment field.
+        $this->database->merge('comment_entity_statistics')
+          ->fields(array(
+            'cid' => $last_reply->cid,
+            'comment_count' => $count,
+            'last_comment_timestamp' => $last_reply->changed,
+            'last_comment_name' => $last_reply->uid ? '' : $last_reply->name,
+            'last_comment_uid' => $last_reply->uid,
+          ))
+          ->keys(array(
+            'entity_id' => $comment->getCommentedEntityId(),
+            'entity_type' => $comment->getCommentedEntityTypeId(),
+            'field_name' => $comment->getFieldName(),
+          ))
+          ->execute();
+      }
+      else {
+        // Comments do not exist.
+        $entity = $comment->getCommentedEntity();
+        // Get the user ID from the entity if it's set, or default to the
+        // currently logged in user.
+        if ($entity instanceof EntityOwnerInterface) {
+          $last_comment_uid = $entity->getOwnerId();
+        }
+        if (!isset($last_comment_uid)) {
+          // Default to current user when entity does not implement
+          // EntityOwnerInterface or author is not set.
+          $last_comment_uid = $this->currentUser->id();
+        }
+        $this->database->update('comment_entity_statistics')
+          ->fields(array(
+            'cid' => 0,
+            'comment_count' => 0,
+            // Use the created date of the entity if it's set, or default to
+            // REQUEST_TIME.
+            'last_comment_timestamp' => ($entity instanceof EntityChangedInterface) ? $entity->getChangedTimeAcrossTranslations() : REQUEST_TIME,
+            'last_comment_name' => '',
+            'last_comment_uid' => $last_comment_uid,
+          ))
+          ->condition('entity_id', $comment->getCommentedEntityId())
+          ->condition('entity_type', $comment->getCommentedEntityTypeId())
+          ->condition('field_name', $comment->getFieldName())
+          ->execute();
+      }
+
+      // Reset the cache of the commented entity so that when the entity is loaded
+      // the next time, the statistics will be loaded again. But don't do this for
+      // stub entities since they don't have all the necessary data at this point.
+      if (!$comment->_rev->is_stub) {
+        $this->entityManager->getStorage($comment->getCommentedEntityTypeId())->resetCache([$comment->getCommentedEntityId()]);
+      }
     }
     else {
-      // Comments do not exist.
-      $entity = $comment->getCommentedEntity();
-      // Get the user ID from the entity if it's set, or default to the
-      // currently logged in user.
-      if ($entity instanceof EntityOwnerInterface) {
-        $last_comment_uid = $entity->getOwnerId();
-      }
-      if (!isset($last_comment_uid)) {
-        // Default to current user when entity does not implement
-        // EntityOwnerInterface or author is not set.
-        $last_comment_uid = $this->currentUser->id();
-      }
-      $this->database->update('comment_entity_statistics')
-        ->fields(array(
-          'cid' => 0,
-          'comment_count' => 0,
-          // Use the created date of the entity if it's set, or default to
-          // REQUEST_TIME.
-          'last_comment_timestamp' => ($entity instanceof EntityChangedInterface) ? $entity->getChangedTimeAcrossTranslations() : REQUEST_TIME,
-          'last_comment_name' => '',
-          'last_comment_uid' => $last_comment_uid,
-        ))
-        ->condition('entity_id', $comment->getCommentedEntityId())
-        ->condition('entity_type', $comment->getCommentedEntityTypeId())
-        ->condition('field_name', $comment->getFieldName())
-        ->execute();
-    }
-
-    // Reset the cache of the commented entity so that when the entity is loaded
-    // the next time, the statistics will be loaded again. But don't do this for
-    // stub entities since they don't have all the necessary data at this point.
-    if (!$comment->_rev->is_stub) {
-      $this->entityManager->getStorage($comment->getCommentedEntityTypeId())->resetCache([$comment->getCommentedEntityId()]);
+      parent::update($comment);
     }
   }
 

--- a/src/Form/MultiversionUninstallForm.php
+++ b/src/Form/MultiversionUninstallForm.php
@@ -90,19 +90,6 @@ class MultiversionUninstallForm extends FormBase {
       '#button_type' => 'primary',
     ];
 
-    $url = Url::fromRoute('system.admin_config');
-    $form['cancel'] = [
-      '#type' => 'link',
-      '#title' => $this->t('Cancel'),
-      '#attributes' => ['class' => ['button']],
-      '#url' => $url,
-      '#cache' => [
-        'contexts' => [
-          'url.query_args:destination',
-        ],
-      ],
-  ];
-
     return $form;
   }
 

--- a/src/Form/MultiversionUninstallForm.php
+++ b/src/Form/MultiversionUninstallForm.php
@@ -68,7 +68,10 @@ class MultiversionUninstallForm extends FormBase {
    *   The form structure.
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    drupal_set_message('Click the button below before uninstalling Multiversion.', 'warning');
+    $form['message'] = [
+      '#markup' => '<div id="uninstall-messages">' .
+        t('Click the button below before uninstalling Multiversion.') . '</div>'
+    ];
 
     $form['push'] = [
       '#type' => 'submit',
@@ -121,6 +124,7 @@ class MultiversionUninstallForm extends FormBase {
       /** @var \Drupal\multiversion\MultiversionManagerInterface $manager */
       $manager = \Drupal::getContainer()->get('multiversion.manager');
       $manager->disableEntityTypes();
+      \Drupal::service('module_installer')->uninstall(['multiversion']);
       drupal_set_message('Successfully uninstalled Multiversion.');
       $form_state->setRedirect('system.modules_list');
     }

--- a/src/Form/MultiversionUninstallForm.php
+++ b/src/Form/MultiversionUninstallForm.php
@@ -68,7 +68,7 @@ class MultiversionUninstallForm extends FormBase {
    *   The form structure.
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    drupal_set_message('Click the button below before uninstalling Multiversion.', 'warning');
+    drupal_set_message('Click the button below to uninstall Multiversion.', 'warning');
 
     $form['uninstall'] = [
       '#type' => 'submit',

--- a/src/Form/MultiversionUninstallForm.php
+++ b/src/Form/MultiversionUninstallForm.php
@@ -68,10 +68,7 @@ class MultiversionUninstallForm extends FormBase {
    *   The form structure.
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['message'] = [
-      '#markup' => '<div id="uninstall-messages">' .
-        t('Click the button below before uninstalling Multiversion.') . '</div>'
-    ];
+    drupal_set_message('Click the button below before uninstalling Multiversion.', 'warning');
 
     $form['uninstall'] = [
       '#type' => 'submit',
@@ -106,8 +103,6 @@ class MultiversionUninstallForm extends FormBase {
       drupal_set_message('An error occurred while uninstalling Multiversion: ' . $e->getMessage(), 'error');
     }
 
-    $status_messages = ['#type' => 'status_messages'];
-    $response->addCommand(new HtmlCommand('#uninstall-messages', $this->renderer->renderRoot($status_messages)));
     return $response;
   }
 

--- a/src/Form/MultiversionUninstallForm.php
+++ b/src/Form/MultiversionUninstallForm.php
@@ -68,7 +68,12 @@ class MultiversionUninstallForm extends FormBase {
    *   The form structure.
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    drupal_set_message('Click the button below to uninstall Multiversion.', 'warning');
+
+    $form['description'] = [
+      '#prefix' => '<p>',
+      '#markup' => $this->t('Are you sure you want to uninstall Multiversion?'),
+      '#suffix' => '</p>',
+    ];
 
     $form['uninstall'] = [
       '#type' => 'submit',
@@ -84,6 +89,20 @@ class MultiversionUninstallForm extends FormBase {
       ],
       '#button_type' => 'primary',
     ];
+
+    $url = Url::fromRoute('system.admin_config');
+    $form['cancel'] = [
+      '#type' => 'link',
+      '#title' => $this->t('Cancel'),
+      '#attributes' => ['class' => ['button']],
+      '#url' => $url,
+      '#cache' => [
+        'contexts' => [
+          'url.query_args:destination',
+        ],
+      ],
+  ];
+
     return $form;
   }
 

--- a/src/Form/MultiversionUninstallForm.php
+++ b/src/Form/MultiversionUninstallForm.php
@@ -10,12 +10,12 @@ namespace Drupal\multiversion\Form;
 use Behat\Mink\Exception\Exception;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\CloseModalDialogCommand;
-use Drupal\Core\Ajax\HtmlCommand;
 use Drupal\Core\Ajax\RedirectCommand;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
+use Drupal\multiversion\MultiversionManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -26,15 +26,22 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class MultiversionUninstallForm extends FormBase {
 
   /**
-   * @var RendererInterface
+   * @var \Drupal\Core\Render\RendererInterface
    */
   protected $renderer;
 
   /**
-   * @param RendererInterface $renderer
+   * @var \Drupal\multiversion\MultiversionManagerInterface
    */
-  function __construct(RendererInterface $renderer) {
+  protected $multiversionManager;
+
+  /**
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   * @param \Drupal\multiversion\MultiversionManagerInterface $multiversion_manager
+   */
+  function __construct(RendererInterface $renderer, MultiversionManagerInterface $multiversion_manager) {
     $this->renderer = $renderer;
+    $this->multiversionManager = $multiversion_manager;
   }
 
   /**
@@ -42,7 +49,8 @@ class MultiversionUninstallForm extends FormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('renderer')
+      $container->get('renderer'),
+      $container->get('multiversion.manager')
     );
   }
 
@@ -79,7 +87,7 @@ class MultiversionUninstallForm extends FormBase {
       '#type' => 'submit',
       '#value' => t('Uninstall'),
       '#ajax' => [
-        'callback' => [$this, 'submitFormAjax'],
+        'callback' => [$this, 'uninstallAjax'],
         'event' => 'mousedown',
         'prevent' => 'click',
         'progress' => [
@@ -94,25 +102,6 @@ class MultiversionUninstallForm extends FormBase {
   }
 
   /**
-   * @param array $form
-   * @param FormStateInterface $form_state
-   * @return AjaxResponse
-   */
-  public function submitFormAjax(array &$form, FormStateInterface $form_state) {
-    $response = new AjaxResponse();
-    try {
-      $response->addCommand(new CloseModalDialogCommand());
-      drupal_set_message('Successfully uninstalled Multiversion.');
-      $response->addCommand(new RedirectCommand(Url::fromRoute('system.modules_list')->toString()));
-    }
-    catch (Exception $e) {
-      drupal_set_message('An error occurred while uninstalling Multiversion: ' . $e->getMessage(), 'error');
-    }
-
-    return $response;
-  }
-
-  /**
    * Form submission handler.
    *
    * @param array $form
@@ -122,9 +111,7 @@ class MultiversionUninstallForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     try {
-      /** @var \Drupal\multiversion\MultiversionManagerInterface $manager */
-      $manager = \Drupal::getContainer()->get('multiversion.manager');
-      $manager->disableEntityTypes();
+      $this->multiversionManager->disableEntityTypes();
       \Drupal::service('module_installer')->uninstall(['multiversion']);
       drupal_set_message('Successfully uninstalled Multiversion.');
       $form_state->setRedirect('system.modules_list');
@@ -133,4 +120,17 @@ class MultiversionUninstallForm extends FormBase {
       drupal_set_message('An error occurred while uninstalling Multiversion: ' . $e->getMessage(), 'error');
     }
   }
+
+  /**
+   * @param array $form
+   * @param FormStateInterface $form_state
+   * @return AjaxResponse
+   */
+  public function uninstallAjax(array &$form, FormStateInterface $form_state) {
+    $response = new AjaxResponse();
+    $response->addCommand(new CloseModalDialogCommand());
+    $response->addCommand(new RedirectCommand(Url::fromRoute('system.modules_list')->toString()));
+    return $response;
+  }
+
 }

--- a/src/Form/MultiversionUninstallForm.php
+++ b/src/Form/MultiversionUninstallForm.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\multiversion\Form\MultiversionUninstallForm.
+ */
+
+namespace Drupal\multiversion\Form;
+
+use Behat\Mink\Exception\Exception;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\CloseModalDialogCommand;
+use Drupal\Core\Ajax\HtmlCommand;
+use Drupal\Core\Ajax\RedirectCommand;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class MultiversionUninstallForm.
+ *
+ * @package Drupal\deploy\Form
+ */
+class MultiversionUninstallForm extends FormBase {
+
+  /**
+   * @var RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * @param RendererInterface $renderer
+   */
+  function __construct(RendererInterface $renderer) {
+    $this->renderer = $renderer;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('renderer')
+    );
+  }
+
+  /**
+   * Returns a unique string identifying the form.
+   *
+   * @return string
+   *   The unique string identifying the form.
+   */
+  public function getFormId() {
+    return 'uninstall_form';
+  }
+
+  /**
+   * Form constructor.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return array
+   *   The form structure.
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    drupal_set_message('Click the button below before uninstalling Multiversion.', 'warning');
+
+    $form['push'] = [
+      '#type' => 'submit',
+      '#value' => t('Uninstall'),
+      '#ajax' => [
+        'callback' => [$this, 'submitFormAjax'],
+        'event' => 'mousedown',
+        'prevent' => 'click',
+        'progress' => [
+          'type' => 'throbber',
+          'message' => 'Uninstalling Multiversion...',
+        ],
+      ],
+      '#button_type' => 'primary',
+    ];
+    return $form;
+  }
+
+  /**
+   * @param array $form
+   * @param FormStateInterface $form_state
+   * @return AjaxResponse
+   */
+  public function submitFormAjax(array &$form, FormStateInterface $form_state) {
+    $response = new AjaxResponse();
+    try {
+      $response->addCommand(new CloseModalDialogCommand());
+      drupal_set_message('Successfully uninstalled Multiversion.');
+      $response->addCommand(new RedirectCommand(Url::fromRoute('system.modules_list')->toString()));
+    }
+    catch (Exception $e) {
+      drupal_set_message('An error occurred while uninstalling Multiversion: ' . $e->getMessage(), 'error');
+    }
+
+    $status_messages = ['#type' => 'status_messages'];
+    $response->addCommand(new HtmlCommand('#uninstall-messages', $this->renderer->renderRoot($status_messages)));
+    return $response;
+  }
+
+  /**
+   * Form submission handler.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    try {
+      /** @var \Drupal\multiversion\MultiversionManagerInterface $manager */
+      $manager = \Drupal::getContainer()->get('multiversion.manager');
+      $manager->disableEntityTypes();
+      drupal_set_message('Successfully uninstalled Multiversion.');
+      $form_state->setRedirect('system.modules_list');
+    }
+    catch (Exception $e) {
+      drupal_set_message('An error occurred while uninstalling Multiversion: ' . $e->getMessage(), 'error');
+    }
+  }
+}

--- a/src/Form/MultiversionUninstallForm.php
+++ b/src/Form/MultiversionUninstallForm.php
@@ -73,7 +73,7 @@ class MultiversionUninstallForm extends FormBase {
         t('Click the button below before uninstalling Multiversion.') . '</div>'
     ];
 
-    $form['push'] = [
+    $form['uninstall'] = [
       '#type' => 'submit',
       '#value' => t('Uninstall'),
       '#ajax' => [

--- a/src/MultiversionManager.php
+++ b/src/MultiversionManager.php
@@ -373,7 +373,7 @@ class MultiversionManager implements MultiversionManagerInterface, ContainerAwar
       // definition.
       if ($has_data[$entity_type_id]) {
         $storage = $this->entityManager->getStorage($entity_type_id);
-        $migration->emptyMultiversionStorage($entity_type, $storage);
+        $migration->emptyOldStorage($entity_type, $storage);
       }
     }
 

--- a/src/MultiversionManager.php
+++ b/src/MultiversionManager.php
@@ -294,6 +294,10 @@ class MultiversionManager implements MultiversionManagerInterface, ContainerAwar
     // Definitions will now be updated. So fetch the new ones.
     $entity_types = $this->getSupportedEntityTypes();
 
+    // Temporarily disable the maintenance of the {comment_entity_statistics} table.
+    $this->state->set('comment.maintain_entity_statistics', FALSE);
+    \Drupal::state()->resetCache();
+
     foreach ($entity_types as $entity_type_id => $entity_type) {
       // Drop unique key from uuid on each entity type.
       $base_table = $entity_type->getBaseTable();
@@ -306,10 +310,14 @@ class MultiversionManager implements MultiversionManagerInterface, ContainerAwar
         $migration->cleanupMigration($entity_type_id . '__to_tmp');
         $migration->cleanupMigration($entity_type_id . '__from_tmp');
       }
+
       // Mark the migration for this particular entity type as done even if no
       // actual content was migrated.
       $this->state->set("multiversion.migration_done.$entity_type_id", TRUE);
     }
+
+    // Enable the the maintenance of entity statistics for comments.
+    $this->state->set('comment.maintain_entity_statistics', TRUE);
 
     // Clean up after us.
     $migration->uninstallDependencies();
@@ -403,6 +411,10 @@ class MultiversionManager implements MultiversionManagerInterface, ContainerAwar
     self::migrationIsActive(TRUE);
     $migration->applyNewStorage();
 
+    // Temporarily disable the maintenance of the {comment_entity_statistics} table.
+    $this->state->set('comment.maintain_entity_statistics', FALSE);
+    \Drupal::state()->resetCache();
+
     // Definitions will now be updated. So fetch the new ones.
     $entity_types = $this->getSupportedEntityTypes();
     foreach ($entity_types as $entity_type_id => $entity_type) {
@@ -420,6 +432,9 @@ class MultiversionManager implements MultiversionManagerInterface, ContainerAwar
 
       $this->state->delete("multiversion.migration_done.$entity_type_id");
     }
+
+    // Enable the the maintenance of entity statistics for comments.
+    $this->state->set('comment.maintain_entity_statistics', TRUE);
 
     // Clean up after us.
     $migration->uninstallDependencies();

--- a/src/MultiversionManager.php
+++ b/src/MultiversionManager.php
@@ -389,12 +389,13 @@ class MultiversionManager implements MultiversionManagerInterface, ContainerAwar
     foreach ($entity_manager->getDefinitions() as $entity_type) {
       if ($entity_type->isSubclassOf(FieldableEntityInterface::CLASS)) {
         $entity_type_id = $entity_type->id();
+        $revision_key = $entity_type->getKey('revision');
         /** @var \Drupal\Core\Entity\FieldableEntityStorageInterface $storage */
         $storage = $entity_manager->getStorage($entity_type_id);
         foreach ($entity_manager->getFieldStorageDefinitions($entity_type_id) as $storage_definition) {
           // @todo We need to trigger field purging here.
           //   See https://www.drupal.org/node/2282119.
-          if ($storage_definition->getProvider() == 'multiversion' && !$storage->countFieldData($storage_definition, TRUE) && $storage_definition->getName() != 'revision_id') {
+          if ($storage_definition->getProvider() == 'multiversion' && !$storage->countFieldData($storage_definition, TRUE) && $storage_definition->getName() != $revision_key) {
             $update_manager->uninstallFieldStorageDefinition($storage_definition);
           }
         }

--- a/src/MultiversionManagerInterface.php
+++ b/src/MultiversionManagerInterface.php
@@ -49,6 +49,11 @@ interface MultiversionManagerInterface {
   public function enableEntityTypes();
 
   /**
+   * @return \Drupal\multiversion\MultiversionManagerInterface
+   */
+  public function disableEntityTypes();
+
+  /**
    * @return integer
    */
   public function newSequenceId();

--- a/src/MultiversionMigration.php
+++ b/src/MultiversionMigration.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\multiversion;
 
-use Drupal\Component\Utility\Html;
 use Drupal\Core\Database\Database;
 use Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface;
 use Drupal\Core\Entity\EntityManagerInterface;
@@ -108,6 +107,17 @@ class MultiversionMigration implements MultiversionMigrationInterface {
     $entities = $storage->loadMultiple();
     if ($entities) {
       $storage->delete($entities);
+    }
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function emptyMultiversionStorage(EntityTypeInterface $entity_type, EntityStorageInterface $storage) {
+    $entities = $storage->loadMultiple();
+    if ($entities) {
+      $storage->purge($entities);
     }
     return $this;
   }

--- a/src/MultiversionMigration.php
+++ b/src/MultiversionMigration.php
@@ -13,6 +13,7 @@ use Drupal\migrate\Entity\Migration;
 use Drupal\migrate\Entity\MigrationInterface;
 use Drupal\migrate\MigrateExecutable;
 use Drupal\migrate\MigrateMessage;
+use Drupal\multiversion\Entity\Storage\ContentEntityStorageInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class MultiversionMigration implements MultiversionMigrationInterface {
@@ -106,18 +107,15 @@ class MultiversionMigration implements MultiversionMigrationInterface {
   public function emptyOldStorage(EntityTypeInterface $entity_type, EntityStorageInterface $storage) {
     $entities = $storage->loadMultiple();
     if ($entities) {
-      $storage->delete($entities);
-    }
-    return $this;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function emptyMultiversionStorage(EntityTypeInterface $entity_type, EntityStorageInterface $storage) {
-    $entities = $storage->loadMultiple();
-    if ($entities) {
-      $storage->purge($entities);
+      // Purge entities if the storage class is an instance of
+      // \Drupal\multiversion\Entity\Storage\ContentEntityStorageInterface,
+      // delete entities otherwise.
+      if ($storage instanceof ContentEntityStorageInterface) {
+        $storage->purge($entities);
+      }
+      else {
+        $storage->delete($entities);
+      }
     }
     return $this;
   }

--- a/src/MultiversionMigration.php
+++ b/src/MultiversionMigration.php
@@ -164,6 +164,15 @@ class MultiversionMigration implements MultiversionMigrationInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function cleanupMigration($id) {
+    if ($migration = Migration::load($id)) {
+      $migration->getIdMap()->destroy();
+    }
+  }
+
+  /**
    * Helper method to fetch the field map for an entity type.
    *
    * @param EntityTypeInterface $entity_type
@@ -221,4 +230,5 @@ class MultiversionMigration implements MultiversionMigrationInterface {
     $executable->import();
     return $executable;
   }
+
 }

--- a/src/MultiversionMigrationInterface.php
+++ b/src/MultiversionMigrationInterface.php
@@ -37,13 +37,6 @@ interface MultiversionMigrationInterface {
   public function emptyOldStorage(EntityTypeInterface $entity_type, EntityStorageInterface $storage);
 
   /**
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
-   * @return \Drupal\multiversion\MultiversionMigrationInterface
-   */
-  public function emptyMultiversionStorage(EntityTypeInterface $entity_type, EntityStorageInterface $storage);
-
-  /**
    * @return \Drupal\multiversion\MultiversionMigrationInterface
    */
   public function applyNewStorage();

--- a/src/MultiversionMigrationInterface.php
+++ b/src/MultiversionMigrationInterface.php
@@ -59,4 +59,12 @@ interface MultiversionMigrationInterface {
    */
   public function uninstallDependencies();
 
+  /**
+   * Removes the map and message tables for a migration.
+   *
+   * @param int $id
+   *   The migration ID.
+   */
+  public function cleanupMigration($id);
+
 }

--- a/src/MultiversionMigrationInterface.php
+++ b/src/MultiversionMigrationInterface.php
@@ -37,6 +37,13 @@ interface MultiversionMigrationInterface {
   public function emptyOldStorage(EntityTypeInterface $entity_type, EntityStorageInterface $storage);
 
   /**
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
+   * @return \Drupal\multiversion\MultiversionMigrationInterface
+   */
+  public function emptyMultiversionStorage(EntityTypeInterface $entity_type, EntityStorageInterface $storage);
+
+  /**
    * @return \Drupal\multiversion\MultiversionMigrationInterface
    */
   public function applyNewStorage();

--- a/src/Plugin/migrate/process/TextFieldProcess.php
+++ b/src/Plugin/migrate/process/TextFieldProcess.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\multiversion\Plugin\migrate\process\TextFieldProcess.
+ */
+
+namespace Drupal\multiversion\Plugin\migrate\process;
+
+use Drupal\Component\Utility\Html;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * @MigrateProcessPlugin(
+ *   id = "text_field_process"
+ * )
+ */
+class TextFieldProcess extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    // Escapes text by converting special characters to HTML entities.
+    return Html::escape($value);
+  }
+
+}

--- a/src/Tests/UninstallTest.php
+++ b/src/Tests/UninstallTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\multiversion\Tests\UninstallTest.
+ */
+
+namespace Drupal\multiversion\Tests;
+
+use Drupal\Core\Entity\ContentEntityStorageInterface;
+use Drupal\Core\Entity\Query\QueryInterface;
+use Drupal\simpletest\WebTestBase;
+
+/**
+ * Test the UninstallTest class.
+ *
+ * @group multiversion
+ */
+class UninstallTest extends WebTestBase {
+
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * @var \Drupal\Core\Extension\ModuleInstallerInterface
+   */
+  protected $moduleInstaller;
+
+  /**
+   * The entity definition update manager.
+   *
+   * @var \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface
+   */
+  protected $entityDefinitionUpdateManager;
+
+  /**
+   * @var array
+   */
+  protected $entityTypes = [
+//    'entity_test' => [],
+//    'entity_test_rev' => [],
+//    'entity_test_mul' => [],
+//    'entity_test_mulrev' => [],
+    'user' => [],
+    'node' => ['type' => 'article', 'title' => 'foo'],
+    'taxonomy_term' => ['name' => 'A term', 'vid' => 123],
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    //'entity_test',
+    'node',
+    'comment',
+    'menu_link_content',
+    'block_content',
+    'taxonomy',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->moduleInstaller = \Drupal::service('module_installer');
+
+    $this->drupalCreateContentType(['type' => 'article', 'name' => 'Article']);
+
+    $this->drupalLogin($this->rootUser);
+  }
+
+  public function testDisableWithExistingContent() {
+    // Install Multiversion.
+    $this->moduleInstaller->install(['multiversion']);
+
+    // Check if all updates have been applied.
+    $this->assertFalse(\Drupal::service('entity.definition_update_manager')->needsUpdates(), 'All compatible entity types have been updated.');
+
+    foreach ($this->entityTypes as $entity_type_id => $values) {
+      $storage = \Drupal::entityTypeManager()->getStorage($entity_type_id);
+
+      if ($entity_type_id == 'user') {
+        $this->createUser(['administer nodes']);
+        // There should now be 3 users in total, including the initial anonymous
+        // and admin users.
+        $count = 3;
+      }
+      // Generic handling for the rest of the entity types.
+      else {
+        $count = 2;
+        for ($i = 0; $i < $count; $i++) {
+          $storage->create($values)->save();
+        }
+      }
+      $count_before[$entity_type_id] = $count;
+    }
+
+    drupal_flush_all_caches();
+
+    // Now uninstall Multiversion.
+    $this->drupalPostAjaxForm('/admin/config/multiversion-uninstall', [], ['op' => t('Uninstall')]);
+    $this->assertFalse(\Drupal::service('entity.definition_update_manager')->needsUpdates(), 'There are not new updates to apply.');
+
+    $manager = \Drupal::entityTypeManager();
+    $manager->clearCachedDefinitions();
+
+    $ids_after = [];
+    // Now check that the previously created entities still exist, have the
+    // right IDs and are multiversion enabled. That means profit. Big profit.
+    foreach ($this->entityTypes as $entity_type_id => $values) {
+      $storage = $manager->getStorage($entity_type_id);
+
+      $this->assertTrue($storage instanceof ContentEntityStorageInterface, "$entity_type_id got the correct storage handler assigned.");
+      $this->assertTrue($storage->getQuery() instanceof QueryInterface, "$entity_type_id got the correct query handler assigned.");
+
+      $ids_after[$entity_type_id] = $storage->getQuery()->execute();
+      $this->assertEqual($count_before[$entity_type_id], count($ids_after[$entity_type_id]), "All ${entity_type_id}s were migrated.");
+    }
+  }
+
+}


### PR DESCRIPTION
What's done: 
- Content migration when uninstalling the module - on a custom admin page (the module can be successfully installed again)
- HTML escaping for test fields 
- Comments migration
- Finish to implement `UninstallTest` class
