### PR TITLE
Original entity

### DIFF
--- a/src/Entity/Storage/ContentEntityStorageTrait.php
+++ b/src/Entity/Storage/ContentEntityStorageTrait.php
@@ -1,14 +1,8 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\multiversion\Entity\Storage\ContentEntityStorageTrait.
- */
-
 namespace Drupal\multiversion\Entity\Storage;
 
 use Drupal\Core\Cache\CacheBackendInterface;
-use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\file\FileInterface;

--- a/src/Entity/Storage/ContentEntityStorageTrait.php
+++ b/src/Entity/Storage/ContentEntityStorageTrait.php
@@ -8,6 +8,7 @@
 namespace Drupal\multiversion\Entity\Storage;
 
 use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityStorageException;
 use Drupal\file\FileInterface;
@@ -159,6 +160,25 @@ trait ContentEntityStorageTrait {
       $entity->_rev->new_edit = FALSE;
       throw new EntityStorageException($e->getMessage(), $e->getCode(), $e);
     }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doPreSave(EntityInterface $entity) {
+    if (!$entity->isNew() && !isset($entity->original) && $entity->originalId) {
+      $entity->original = $this->loadUnchanged($entity->originalId);
+    }
+    parent::doPreSave($entity);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doPostSave(EntityInterface $entity, $update) {
+    parent::doPostSave($entity, $update);
+    // Set the originalId to allow entity renaming.
+    $entity->originalId = $entity->id();
   }
 
   /**

--- a/src/Tests/EntityStorageTest.php
+++ b/src/Tests/EntityStorageTest.php
@@ -262,11 +262,6 @@ class EntityStorageTest extends MultiversionWebTestBase {
       $first_id = $entity->id();
       $first_rev = $entity->_rev->value;
       try {
-        // Temporary solution.
-        // @todo: {@link https://www.drupal.org/node/2597516 Remove now that
-        // https://www.drupal.org/node/2453153 is fixed.}
-        $entity->original = clone $entity;
-
         // Trigger an error by setting the ID too large.
         $entity->{$id_key}->value = PHP_INT_MAX;
         $entity->save();


### PR DESCRIPTION
Remove todo from code and allow entity renaming by setting the original ID and original entity.