### PR TITLE
Fix fatal error on stub menu links

### DIFF
--- a/src/MenuTreeStorage.php
+++ b/src/MenuTreeStorage.php
@@ -87,7 +87,10 @@ class MenuTreeStorage extends CoreMenuTreeStorage {
         }
         elseif (!$parent) {
           // Create a new menu link as stub.
-          $parent = $storage->create(['uuid' => $uuid]);
+          $parent = $storage->create([
+            'uuid' => $uuid,
+            'link' => 'internal:/',
+          ]);
           // Indicate that this revision is a stub.
           $parent->_rev->is_stub = TRUE;
           $parent->save();


### PR DESCRIPTION
I was getting a fatal error on MenuLinkContent::getUrlObject when using InternalReplicator. This fixes it.

The stub entity needs the link field to be set. When the stubbed entity is filled, the link field will get set to the real value.